### PR TITLE
Update profile queries to use findFirst and fix schema

### DIFF
--- a/app/(main)/(routes)/conversations/layout.tsx
+++ b/app/(main)/(routes)/conversations/layout.tsx
@@ -21,7 +21,7 @@ const ConversationsLayout = async ({ children }: { children: React.ReactNode }) 
   try {
     await db.profile.update({
       where: {
-        userId: profile.userId,
+        id: profile.id,
       },
       data: {
         name: `${user?.username}`,

--- a/lib/current-profile-pages.ts
+++ b/lib/current-profile-pages.ts
@@ -8,7 +8,7 @@ export const currentProfilePages = async (req: NextApiRequest) => {
 
   if (!userId) return null;
 
-  const profile = await db.profile.findUnique({
+  const profile = await db.profile.findFirst({
     where: {
       userId,
     },

--- a/lib/current-profile.ts
+++ b/lib/current-profile.ts
@@ -7,7 +7,7 @@ export const currentProfile = async () => {
 
   if (!userId) return null;
 
-  const profile = await db.profile.findUnique({
+  const profile = await db.profile.findFirst({
     where: {
       userId,
     },

--- a/lib/initial-profile.ts
+++ b/lib/initial-profile.ts
@@ -9,7 +9,7 @@ export const initialProfile = async () => {
     if (!user)
       return redirectToSignIn();
 
-    const profile = await db.profile.findUnique({
+    const profile = await db.profile.findFirst({
       where: {
         userId: user.id,
       },

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -87,7 +87,7 @@ enum PermissionScope {
 
 model Profile {
   id         String  @id @default(uuid())
-  userId     String  @unique
+  userId     String
   name       String
   globalName String?
   imageUrl   String  @db.Text


### PR DESCRIPTION
Replaces findUnique with findFirst for profile queries in current-profile, current-profile-pages, and initial-profile to support non-unique userId. Updates Prisma schema to remove unique constraint from userId in Profile model. Also updates profile update query to use id instead of userId.